### PR TITLE
Add support for AvaloniaUI 11.3.0

### DIFF
--- a/src/JLeb.Estragonia/BclStorageFolder.cs
+++ b/src/JLeb.Estragonia/BclStorageFolder.cs
@@ -58,6 +58,22 @@ internal sealed class BclStorageFolder : IStorageBookmarkFolder {
 			.Concat(DirectoryInfo.EnumerateFiles().Select(f => new BclStorageFile(f)))
 			.AsAsyncEnumerable();
 
+	public Task<IStorageFolder?> GetFolderAsync(string name) {
+		var directory = DirectoryInfo.EnumerateDirectories().FirstOrDefault(d => d.Name == name);
+		if (directory is null)
+			return Task.FromResult<IStorageFolder?>(null);
+
+		return Task.FromResult<IStorageFolder?>(new BclStorageFolder(directory));
+	}
+
+	public Task<IStorageFile?> GetFileAsync(string name) {
+		var file = DirectoryInfo.EnumerateFiles().FirstOrDefault(f => f.Name == name);
+		if (file is null)
+			return Task.FromResult<IStorageFile?>(null);
+
+		return Task.FromResult<IStorageFile?>(new BclStorageFile(file));
+	}
+
 	public Task<string?> SaveBookmarkAsync()
 		=> Task.FromResult<string?>(DirectoryInfo.FullName);
 

--- a/src/JLeb.Estragonia/GodotClipboard.cs
+++ b/src/JLeb.Estragonia/GodotClipboard.cs
@@ -20,6 +20,9 @@ internal sealed class GodotClipboard : IClipboard {
 	public Task ClearAsync()
 		=> SetTextAsync(String.Empty);
 
+	public Task FlushAsync()
+		=> Task.CompletedTask;
+
 	public Task SetDataObjectAsync(IDataObject data)
 		=> Task.CompletedTask;
 
@@ -28,5 +31,8 @@ internal sealed class GodotClipboard : IClipboard {
 
 	public Task<object?> GetDataAsync(string format)
 		=> Task.FromResult<object?>(null);
+
+	public Task<IDataObject?> TryGetInProcessDataObjectAsync()
+		=> Task.FromResult<IDataObject?>(null);
 
 }

--- a/src/JLeb.Estragonia/JLeb.Estragonia.csproj
+++ b/src/JLeb.Estragonia/JLeb.Estragonia.csproj
@@ -30,7 +30,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="GodotSharp" Version="4.3.0" />
-		<PackageReference Include="Avalonia.Skia" Version="[11.2.3]" />
+		<PackageReference Include="Avalonia.Skia" Version="[11.3.0]" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 	</ItemGroup>
 


### PR DESCRIPTION
AvaloniaUI added some methods to the interfaces used in the setup, this just adds the basic implementation for them so Avalonia 11.3.0 can be used.