### PR TITLE
Make PickFilesAsync work correctly with async Tasks

### DIFF
--- a/src/JLeb.Estragonia/GodotStorageProvider.cs
+++ b/src/JLeb.Estragonia/GodotStorageProvider.cs
@@ -114,6 +114,8 @@ internal sealed class GodotStorageProvider : IStorageProvider {
 		else
 			dialog.FileSelected += OnFileSelected;
 
+		dialog.Canceled += OnCancelled;
+
 		void OnFilesSelected(string[] paths) {
 			dialog.FilesSelected -= OnFilesSelected;
 			taskCompletionSource.SetResult(paths.Select(path => new BclStorageFile(new FileInfo(path))).ToArray());
@@ -122,6 +124,11 @@ internal sealed class GodotStorageProvider : IStorageProvider {
 		void OnFileSelected(string path) {
 			dialog.FileSelected -= OnFileSelected;
 			taskCompletionSource.SetResult(new[] { new BclStorageFile(new FileInfo(path)) });
+		}
+
+		void OnCancelled() {
+			dialog.Canceled -= OnCancelled;
+			taskCompletionSource.SetResult(Array.Empty<BclStorageFile>());
 		}
 
 		dialog.Show();

--- a/src/JLeb.Estragonia/GodotStorageProvider.cs
+++ b/src/JLeb.Estragonia/GodotStorageProvider.cs
@@ -107,26 +107,26 @@ internal sealed class GodotStorageProvider : IStorageProvider {
 				dialog.AddFilter(String.Join(',', fileType.Patterns ?? Array.Empty<string>()), fileType.Name);
 		}
 
+		var taskCompletionSource = new TaskCompletionSource<IReadOnlyList<IStorageFile>>();
+
 		if (fileMode == FileDialog.FileModeEnum.OpenFiles)
 			dialog.FilesSelected += OnFilesSelected;
 		else
 			dialog.FileSelected += OnFileSelected;
 
-		var storageFiles = Array.Empty<BclStorageFile>();
-
 		void OnFilesSelected(string[] paths) {
 			dialog.FilesSelected -= OnFilesSelected;
-			storageFiles = paths.Select(path => new BclStorageFile(new FileInfo(path))).ToArray();
+			taskCompletionSource.SetResult(paths.Select(path => new BclStorageFile(new FileInfo(path))).ToArray());
 		}
 
 		void OnFileSelected(string path) {
 			dialog.FileSelected -= OnFileSelected;
-			storageFiles = new[] { new BclStorageFile(new FileInfo(path)) };
+			taskCompletionSource.SetResult(new[] { new BclStorageFile(new FileInfo(path)) });
 		}
 
 		dialog.Show();
 
-		return Task.FromResult<IReadOnlyList<IStorageFile>>(storageFiles);
+		return taskCompletionSource.Task;
 	}
 
 	private static FileDialog CreateDialog(PickerOptions options, FileDialog.FileModeEnum fileMode)

--- a/src/JLeb.Estragonia/GodotStorageProvider.cs
+++ b/src/JLeb.Estragonia/GodotStorageProvider.cs
@@ -118,16 +118,20 @@ internal sealed class GodotStorageProvider : IStorageProvider {
 
 		void OnFilesSelected(string[] paths) {
 			dialog.FilesSelected -= OnFilesSelected;
+			dialog.Canceled -= OnCancelled;
 			taskCompletionSource.SetResult(paths.Select(path => new BclStorageFile(new FileInfo(path))).ToArray());
 		}
 
 		void OnFileSelected(string path) {
 			dialog.FileSelected -= OnFileSelected;
+			dialog.Canceled -= OnCancelled;
 			taskCompletionSource.SetResult(new[] { new BclStorageFile(new FileInfo(path)) });
 		}
 
 		void OnCancelled() {
 			dialog.Canceled -= OnCancelled;
+			dialog.FilesSelected -= OnFilesSelected;
+			dialog.FileSelected -= OnFileSelected;
 			taskCompletionSource.SetResult(Array.Empty<BclStorageFile>());
 		}
 

--- a/src/JLeb.Estragonia/GodotStorageProvider.cs
+++ b/src/JLeb.Estragonia/GodotStorageProvider.cs
@@ -34,19 +34,29 @@ internal sealed class GodotStorageProvider : IStorageProvider {
 	}
 
 	public Task<IReadOnlyList<IStorageFolder>> OpenFolderPickerAsync(FolderPickerOpenOptions options) {
-		var folders = Array.Empty<IStorageFolder>();
 		var dialog = CreateDialog(options, FileDialog.FileModeEnum.OpenDir);
+
+		var taskCompletionSource = new TaskCompletionSource<IReadOnlyList<IStorageFolder>>();
 
 		dialog.DirSelected += OnDirSelected;
 
 		void OnDirSelected(string dir) {
+			dialog.Canceled -= OnCancelled;
 			dialog.DirSelected -= OnDirSelected;
-			folders = new IStorageFolder[] { new BclStorageFolder(new DirectoryInfo(dir)) };
+			taskCompletionSource.SetResult(new IStorageFolder[] { new BclStorageFolder(new DirectoryInfo(dir)) });
+		}
+
+		dialog.Canceled += OnCancelled;
+
+		void OnCancelled() {
+			dialog.Canceled -= OnCancelled;
+			dialog.DirSelected -= OnDirSelected;
+			taskCompletionSource.SetResult(Array.Empty<BclStorageFolder>());
 		}
 
 		dialog.Show();
 
-		return Task.FromResult<IReadOnlyList<IStorageFolder>>(folders);
+		return taskCompletionSource.Task;
 	}
 
 	public Task<IStorageBookmarkFile?> OpenFileBookmarkAsync(string bookmark) {


### PR DESCRIPTION
PickFilesAsync member of GodotStorageProvider was reacting to FilesSelected and FileSelected to update a captured variable, but still never waited for those and just returned a finished task containing the default Empty list value.

I changed that to make those event handlers instead set the selected files to the result of a TaskCompletionSource, who's unfinished Task is instead returned from PickFilesAsync. 

Additionally, I added a handler for when cancelling the dialog, where the Task would otherwise never finish.